### PR TITLE
fix: deduplicate facet values to prevent duplicate records in search results

### DIFF
--- a/odp/catalog/mims.py
+++ b/odp/catalog/mims.py
@@ -322,7 +322,7 @@ class MIMSCatalog(SAEONCatalog):
                     if subject.strip():
                         facets['Keyword'].append(subject.strip())
 
-        return facets
+        return {k: list(dict.fromkeys(v)) for k, v in facets.items()}
 
     def create_global_data(self) -> Any:
         """Create a JSON-compatible object to be published as global data for the catalog."""


### PR DESCRIPTION

<img width="1858" height="962" alt="Duplicated records (1)" src="https://github.com/user-attachments/assets/bd9df348-33b5-4375-8eb3-301900c5ff92" />

EOV/EBV/SDG/Keyword facets in MIMSCatalog were being populated from both ISO19115 keywords and DataCite subjects. When the same value appeared in both, it produced duplicate catalog_record_facet rows. The JOIN-based search query then returned one result row per duplicate facet row, causing the same record to appear multiple times in search results.

dict.fromkeys preserves insertion order while removing duplicates.