### PR TITLE
Replace server-side ZIP with metadata-bundle endpoint

### DIFF
--- a/odp/api/routers/catalog.py
+++ b/odp/api/routers/catalog.py
@@ -5,13 +5,12 @@ from datetime import date
 from enum import Enum
 from functools import partial
 from math import ceil
-from typing import Any, Optional, List
+from typing import Any
 from urllib.parse import urlparse
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
-from fastapi.responses import RedirectResponse, FileResponse
-from starlette.background import BackgroundTask
+from fastapi.responses import RedirectResponse
 from jschon import JSONPointer
 from jschon.exc import JSONPointerMalformedError, JSONPointerReferenceError
 from pydantic import Json
@@ -20,17 +19,17 @@ from sqlalchemy.orm import aliased, load_only
 from starlette.status import HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY
 
 from odp.api.lib.auth import Authorize
-from odp.config import config
 from odp.api.lib.datacite import get_datacite_client
 from odp.api.lib.paging import Page, Paginator
 from odp.api.lib.utils import output_published_record_model
-from odp.api.models import (CatalogModel, CatalogModelWithData, PublishedDataCiteRecordModel, PublishedSAEONRecordModel,
+from odp.api.models import (CatalogModel, CatalogModelWithData, MetadataBundleResponse,
+                            PublishedDataCiteRecordModel, PublishedSAEONRecordModel,
                             RetractedRecordModel, SearchResult, UserData)
 from odp.const import DOI_REGEX, ODPCatalog, ODPScope
 from odp.db import Session
 from odp.db.models import Catalog, CatalogRecord, CatalogRecordFacet, PublishedRecord, Record
 from odp.lib.datacite import DataciteClient, DataciteError
-from odp.lib.record_dataset_bundler import bundle_catalog_records
+from odp.lib.record_dataset_bundler import generate_metadata_bundle
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -353,7 +352,7 @@ async def get_metadata_value(
 
 @router.get(
     '/{catalog_id}/external/{record_id}',
-    response_model=Optional[dict[str, Any]],
+    response_model=dict[str, Any] | None,
     dependencies=[Depends(Authorize(ODPScope.CATALOG_READ))],
 )
 async def get_external_record(
@@ -404,7 +403,7 @@ async def redirect_to(
 )
 async def records_subset(
         catalog_id: str,
-        record_id_or_doi_list: List[str] = Query(..., alias="record_id_or_doi_list"),
+        record_id_or_doi_list: list[str] = Query(..., alias="record_id_or_doi_list"),
         page: int = 1,
         size: int = 50
 ):
@@ -466,75 +465,40 @@ async def records_subset(
 
 
 @router.post(
-    '/generate-zip-bundle',
-    response_class=FileResponse,
-    summary='Generate server-side ZIP bundle',
-    description='Generate a server-side ZIP file containing metadata PDFs and data files for selected records',
-    status_code=200,
+    '/metadata-bundle',
+    response_model=MetadataBundleResponse,
+    summary='Generate metadata bundle (client-side ZIP)',
     dependencies=[Depends(Authorize(ODPScope.CATALOG_READ))],
 )
-def generate_zip_bundle(
+def metadata_bundle(
         record_ids: list[str],
         user_data: UserData,
-        request: Request
+        request: Request,
+        client_ip: str | None = None,
+        user_agent: str | None = None,
+        referer: str | None = None,
 ):
-    """
-    Generate ZIP bundle with metadata PDFs and data files.
-
-    Explicit parameters:
-    - **record_ids**: List of DOIs to include (non-empty array)
-    - **user_data**: User information object with name, email, organisation (all required)
-
-    The endpoint automatically extracts client IP and user-agent from HTTP headers
-    for audit logging purposes.
-
-    Returns binary ZIP file with structure:
-        /Record_Title/metadata.pdf
-        /Record_Title/data_file
-
-    Response headers:
-    - X-Bundle-Record-Count: Number of successfully processed records
-    - X-Bundle-Failed-Count: Number of failed records
-    """
+    """Return metadata PDFs (base64) + data file URLs per record. No data file downloading."""
     try:
-
-        client_ip = request.client.host if request.client else None
-        user_agent = request.headers.get('user-agent')
-
-        # Derive catalog base URL from the browser's Referer header
-        referer = request.headers.get('referer', '')
-        if referer:
-            parsed = urlparse(referer)
+        resolved_ip = client_ip or (request.client.host if request.client else None)
+        resolved_ua = user_agent or request.headers.get('user-agent')
+        resolved_referer = referer or request.headers.get('referer', '')
+        catalog_url = None
+        if resolved_referer:
+            parsed = urlparse(resolved_referer)
             catalog_url = f"{parsed.scheme}://{parsed.netloc}"
-        else:
-            catalog_url = config.ODP.API_URL
 
-        result = bundle_catalog_records(
+        return generate_metadata_bundle(
             record_ids=record_ids,
             user_data=user_data.dict(),
-            client_ip=client_ip,
-            user_agent=user_agent,
+            client_ip=resolved_ip,
+            user_agent=resolved_ua,
             catalog_url=catalog_url,
         )
-
-        background_task = BackgroundTask(os.remove, result.zip_path)
-
-        return FileResponse(
-            result.zip_path,
-            media_type='application/zip',
-            filename="records.zip",
-            background=background_task,
-            headers={
-                'X-Bundle-Record-Count': str(result.record_count),
-                'X-Bundle-Failed-Count': str(result.failed_count),
-            }
-        )
-
     except HTTPException:
         raise
     except ValueError as e:
-        logger.warning(f"ZIP generation validation error: {str(e)}")
         raise HTTPException(400, str(e))
     except Exception as e:
-        logger.error(f"ZIP generation error: {str(e)}")
+        logger.error(f"Metadata bundle error: {e}", exc_info=True)
         raise HTTPException(500, "Internal server error")

--- a/odp/lib/record_dataset_bundler.py
+++ b/odp/lib/record_dataset_bundler.py
@@ -1,22 +1,18 @@
 """
-Server-side ZIP bundle generation with metadata PDFs and data files.
+Metadata bundle generation for client-side ZIP downloads.
 """
 
+import base64
 import logging
 import mimetypes
 import os
 import re
-import tempfile
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
-from zipfile import ZipFile, ZIP_DEFLATED
 
-import requests
-from fastapi import HTTPException
 from sqlalchemy import select
 
-from odp.api.models import BundledRecordDataset
+from odp.api.models import MetadataBundleRecord, MetadataBundleResponse
 from odp.const import ODPCatalog
 from odp.db import Session
 from odp.db.models import CatalogRecord, DownloadAudit
@@ -61,27 +57,6 @@ def create_safe_folder_name(doi: str, title: str, max_length: int = 200) -> str:
     return name or 'Untitled'
 
 
-def fetch_external_file(url: str, timeout: int = 30) -> Tuple[Optional[bytes], Optional[str]]:
-    """Download a file and return (bytes, content_type). Both None on failure."""
-    if not url:
-        return None, None
-    try:
-        response = requests.get(url + '/download', timeout=timeout, stream=True)
-        if not response.ok:
-            logger.warning(f"Download failed (HTTP {response.status_code}): {url}")
-            return None, None
-
-        content_type = response.headers.get('Content-Type', '').split(';')[0].strip()
-        file_bytes = b''
-        for chunk in response.iter_content(chunk_size=8192):
-            if chunk:
-                file_bytes += chunk
-        return (file_bytes or None), content_type
-    except Exception as e:
-        logger.error(f"Download error: {str(e)}")
-        return None, None
-
-
 def _ensure_extension(file_name: str, download_url: str, content_type: str) -> str:
     """Append a file extension if file_name has none, using URL path or Content-Type."""
     if os.path.splitext(file_name)[1]:
@@ -100,131 +75,10 @@ def _ensure_extension(file_name: str, download_url: str, content_type: str) -> s
     return file_name + ext if ext else file_name
 
 
-def bundle_catalog_records(
-        record_ids: List[str],
-        user_data: Dict[str, str],
-        client_ip: Optional[str] = None,
-        user_agent: Optional[str] = None,
-        catalog_url: Optional[str] = None,
-) -> BundledRecordDataset:
-    """Generates a ZIP bundle of metadata PDFs and data files for the given catalog record IDs."""
-
-    if not record_ids:
-        raise ValueError("record_ids cannot be empty")
-    required = {'name', 'email', 'organisation'}
-    if not required.issubset(user_data) or not all(user_data.get(f) for f in required):
-        raise ValueError("user_data missing required fields: name, email, organisation")
-
-    temp_zip = tempfile.NamedTemporaryFile(delete=False, suffix='.zip')
-    temp_zip_path = temp_zip.name
-    temp_zip.close()
-    
-    total_file_size = 0
-    processed_dois = []
-    failed_records = []
-    MAX_BUNDLE_SIZE = 2 * 1024 * 1024 * 1024  # 2GB
-
-    try:
-        with Session() as session:
-            stmt = (
-                select(CatalogRecord)
-                .where(CatalogRecord.published.is_(True))
-                .where(CatalogRecord.record_id.in_(record_ids))
-                .where(CatalogRecord.catalog_id == ODPCatalog.DATACITE)
-            )
-            catalog_records = session.execute(stmt).scalars().all()
-
-            # Track which IDs were actually found in the DB
-            found_ids = {rec.record_id for rec in catalog_records}
-            for missing_id in set(record_ids) - found_ids:
-                failed_records.append({'doi': missing_id, 'reason': 'not_found_or_not_published'})
-
-            with ZipFile(temp_zip_path, 'w', ZIP_DEFLATED) as zip_file:
-                for catalog_record in catalog_records:
-                    try:
-                        pub_rec = catalog_record.published_record
-                        # Discover metadata: prefer metadata_records, fallback to root
-                        metadata = None
-                        if pub_rec.get("metadata_records"):
-                            metadata = pub_rec["metadata_records"][0].get("metadata")
-                        elif pub_rec.get("metadata"):
-                            metadata = pub_rec.get("metadata")
-
-                        if not metadata:
-                            logger.error(f"No metadata found for {catalog_record.record_id}")
-                            failed_records.append({'doi': catalog_record.record_id, 'reason': 'metadata_missing'})
-                            continue
-
-                        doi = catalog_record.record.doi or catalog_record.record_id
-                        resource = metadata.get("immutableResource")
-
-                        raw_title = (
-                                metadata.get('titles', [{}])[0].get('title') or
-                                metadata.get('title') or
-                                f"Record_{doi}"
-                        )
-                        folder_name = create_safe_folder_name(doi, raw_title)
-
-                        try:
-                            record_metadata = adapt_metadata(metadata)
-                            pdf_buffer = generate_pdf(record_metadata)
-                            pdf_content = pdf_buffer.getvalue()
-
-                            zip_file.writestr(f"{folder_name}/Metadata.pdf", pdf_content)
-                            total_file_size += len(pdf_content)
-                        except Exception as e:
-                            logger.error(f"PDF generation failed for {catalog_record.record_id}: {str(e)}")
-
-                        if resource and 'resourceDownload' in resource:
-                            download_url = resource['resourceDownload'].get('downloadURL')
-                            file_name = resource['resourceDownload'].get('fileName', 'data_file')
-                            if download_url:
-                                file_bytes, content_type = fetch_external_file(download_url)
-                                if file_bytes:
-                                    file_name = _ensure_extension(file_name, download_url, content_type)
-                                    zip_file.writestr(f"{folder_name}/{file_name}", file_bytes)
-                                    total_file_size += len(file_bytes)
-
-                        processed_dois.append(doi)
-
-                        if total_file_size > MAX_BUNDLE_SIZE:
-                            raise HTTPException(413, 'Bundle exceeds 2GB limit')
-
-                    except Exception as e:
-                        logger.error(f"Error processing {catalog_record.record_id}: {str(e)}")
-                        failed_records.append({'doi': catalog_record.record_id, 'reason': 'internal_error'})
-
-        file_size = os.path.getsize(temp_zip_path)
-
-        try:
-            log_bundle_download_audit(
-                record_ids,
-                processed_dois,
-                user_data,
-                file_size,
-                failed_records,
-                client_ip,
-                user_agent,
-                catalog_url,
-            )
-        except Exception as e:
-            logger.error(f"Failed to log audit: {str(e)}")
-
-        return BundledRecordDataset(
-            zip_path=temp_zip_path,
-            total_size=file_size,
-            record_count=len(processed_dois),
-            failed_count=len(failed_records),
-            processed=processed_dois,
-            failed=failed_records,
-        )
-    except Exception as e:
-        if os.path.exists(temp_zip_path):
-            try:
-                os.remove(temp_zip_path)
-            except Exception as rm_e:
-                logger.error(f"Could not remove temp file {temp_zip_path} during error cleanup: {rm_e}")
-        raise e
+def _extract_metadata(pub_rec: dict) -> dict | None:
+    if pub_rec.get("metadata_records"):
+        return pub_rec["metadata_records"][0].get("metadata")
+    return pub_rec.get("metadata")
 
 
 def log_bundle_download_audit(record_ids, dois, user_data, file_size, failed_records, client_ip, user_agent, catalog_url=None):
@@ -247,7 +101,7 @@ def log_bundle_download_audit(record_ids, dois, user_data, file_size, failed_rec
 
     DownloadAudit(
         client_id='odp-server-zip-generator',
-        download_url='/catalog/generate-zip-bundle',
+        download_url='/catalog/metadata-bundle',
         ip_address=client_ip,
         user_agent=user_agent,
         file_size=file_size,
@@ -255,3 +109,104 @@ def log_bundle_download_audit(record_ids, dois, user_data, file_size, failed_rec
         timestamp=datetime.now(timezone.utc),
         meta=audit_meta,
     ).save()
+
+    # Commit here rather than relying on the request-scoped commit middleware:
+    # this function runs in a threadpool worker thread (metadata_bundle is
+    # a sync endpoint), so the thread-local Session it uses is not the same
+    # one the middleware commits on the event-loop thread.
+    try:
+        Session.commit()
+    except Exception:
+        Session.rollback()
+        raise
+
+
+def generate_metadata_bundle(
+        record_ids: list[str],
+        user_data: dict[str, str],
+        client_ip: str | None = None,
+        user_agent: str | None = None,
+        catalog_url: str | None = None,
+) -> MetadataBundleResponse:
+    """Return metadata PDFs (base64) + data file URLs per record. Does NOT download data files."""
+    if not record_ids:
+        raise ValueError("record_ids cannot be empty")
+    required = {'name', 'email', 'organisation'}
+    if not required.issubset(user_data) or not all(user_data.get(f) for f in required):
+        raise ValueError("user_data missing required fields: name, email, organisation")
+
+    records = []
+    failed_records = []
+    processed_dois = []
+
+    with Session() as session:
+        stmt = (
+            select(CatalogRecord)
+            .where(CatalogRecord.published.is_(True))
+            .where(CatalogRecord.record_id.in_(record_ids))
+            .where(CatalogRecord.catalog_id == ODPCatalog.DATACITE)
+        )
+        catalog_records = session.execute(stmt).scalars().all()
+
+        found_ids = {rec.record_id for rec in catalog_records}
+        for missing_id in set(record_ids) - found_ids:
+            failed_records.append({'doi': missing_id, 'reason': 'not_found_or_not_published'})
+
+        for catalog_record in catalog_records:
+            try:
+                pub_rec = catalog_record.published_record
+                metadata = _extract_metadata(pub_rec)
+
+                if not metadata:
+                    failed_records.append({'doi': catalog_record.record_id, 'reason': 'metadata_missing'})
+                    continue
+
+                doi = catalog_record.record.doi or catalog_record.record_id
+                raw_title = (
+                    metadata.get('titles', [{}])[0].get('title') or
+                    metadata.get('title') or
+                    f"Record_{doi}"
+                )
+                folder_name = create_safe_folder_name(doi, raw_title)
+
+                record_metadata = adapt_metadata(metadata)
+                pdf_buffer = generate_pdf(record_metadata)
+                pdf_b64 = base64.b64encode(pdf_buffer.getvalue()).decode('utf-8')
+
+                resource = metadata.get('immutableResource')
+                data_file_url = None
+                data_file_name = None
+                if resource and 'resourceDownload' in resource:
+                    data_file_url = resource['resourceDownload'].get('downloadURL')
+                    data_file_name = resource['resourceDownload'].get('fileName', 'data_file')
+                    if data_file_url and data_file_name:
+                        data_file_name = _ensure_extension(data_file_name, data_file_url, None)
+
+                records.append(MetadataBundleRecord(
+                    folder_name=folder_name,
+                    metadata_pdf=pdf_b64,
+                    data_file_url=data_file_url,
+                    data_file_name=data_file_name,
+                ))
+                processed_dois.append(doi)
+
+            except Exception as e:
+                logger.error(f"Error processing {catalog_record.record_id}: {e}")
+                failed_records.append({'doi': catalog_record.record_id, 'reason': 'internal_error'})
+
+    log_bundle_download_audit(
+        record_ids=record_ids,
+        dois=processed_dois,
+        user_data=user_data,
+        file_size=0,
+        failed_records=failed_records,
+        client_ip=client_ip,
+        user_agent=user_agent,
+        catalog_url=catalog_url,
+    )
+
+    return MetadataBundleResponse(
+        records=records,
+        total=len(records),
+        failed=len(failed_records),
+    )


### PR DESCRIPTION
Remove bundle_catalog_records, fetch_external_file, and the generate-zip-bundle endpoint. The browser now assembles the ZIP via JSZip. The server only generates metadata PDFs and returns data file URLs via the new /catalog/metadata-bundle endpoint (sync def, threadpool-dispatched). Dead imports cleaned up.