### PR TITLE
Store and expose catalog_url in download audit; fix CSV export links

### DIFF
--- a/odp/api/routers/catalog.py
+++ b/odp/api/routers/catalog.py
@@ -22,9 +22,9 @@ from odp.api.lib.auth import Authorize
 from odp.api.lib.datacite import get_datacite_client
 from odp.api.lib.paging import Page, Paginator
 from odp.api.lib.utils import output_published_record_model
-from odp.api.models import (CatalogModel, CatalogModelWithData, MetadataBundleResponse,
-                            PublishedDataCiteRecordModel, PublishedSAEONRecordModel,
-                            RetractedRecordModel, SearchResult, UserData)
+from odp.api.models import (CatalogModel, CatalogModelWithData, MetadataBundleRequest,
+                            MetadataBundleResponse, PublishedDataCiteRecordModel,
+                            PublishedSAEONRecordModel, RetractedRecordModel, SearchResult)
 from odp.const import DOI_REGEX, ODPCatalog, ODPScope
 from odp.db import Session
 from odp.db.models import Catalog, CatalogRecord, CatalogRecordFacet, PublishedRecord, Record
@@ -471,26 +471,22 @@ async def records_subset(
     dependencies=[Depends(Authorize(ODPScope.CATALOG_READ))],
 )
 def metadata_bundle(
-        record_ids: list[str],
-        user_data: UserData,
+        body: MetadataBundleRequest,
         request: Request,
-        client_ip: str | None = None,
-        user_agent: str | None = None,
-        referer: str | None = None,
 ):
     """Return metadata PDFs (base64) + data file URLs per record. No data file downloading."""
     try:
-        resolved_ip = client_ip or (request.client.host if request.client else None)
-        resolved_ua = user_agent or request.headers.get('user-agent')
-        resolved_referer = referer or request.headers.get('referer', '')
+        resolved_ip = body.client_ip or (request.client.host if request.client else None)
+        resolved_ua = body.user_agent or request.headers.get('user-agent')
+        resolved_referer = body.referer or request.headers.get('referer', '')
         catalog_url = None
         if resolved_referer:
             parsed = urlparse(resolved_referer)
             catalog_url = f"{parsed.scheme}://{parsed.netloc}"
 
         return generate_metadata_bundle(
-            record_ids=record_ids,
-            user_data=user_data.dict(),
+            record_ids=body.record_ids,
+            user_data=body.user_data.dict(),
             client_ip=resolved_ip,
             user_agent=resolved_ua,
             catalog_url=catalog_url,

--- a/odp/lib/download_service.py
+++ b/odp/lib/download_service.py
@@ -151,6 +151,7 @@ def get_download_logs(
             ip_address=d.ip_address,
             doi=d.meta.get('doi') if d.meta else None,
             record_ids=d.meta.get('record_ids', []) if d.meta else [],
+            catalog_url=d.meta.get('catalog_url') if d.meta else None,
         )
         for d in downloads
     ]
@@ -184,10 +185,10 @@ def generate_downloads_csv(
         catalog_url = meta.get('catalog_url', '')
         view_link = ""
         if catalog_url and dtype == 'single_record' and meta.get('doi'):
-            view_link = f"{catalog_url}/{meta.get('doi')}"
+            view_link = f"{catalog_url}/catalog/{meta.get('doi')}"
         elif catalog_url and dtype == 'zip_bundle' and meta.get('record_ids'):
             query_string = '&'.join([f'record_id_or_doi_list={rid}' for rid in meta.get('record_ids', [])])
-            view_link = f"{catalog_url}/subset?{query_string}"
+            view_link = f"{catalog_url}/catalog/subset?{query_string}"
 
         writer.writerow([
             d.id, d.timestamp.isoformat(), meta.get('name', ''), meta.get('email', ''),

--- a/odp/lib/record_dataset_bundler.py
+++ b/odp/lib/record_dataset_bundler.py
@@ -181,6 +181,8 @@ def generate_metadata_bundle(
                     data_file_name = resource['resourceDownload'].get('fileName', 'data_file')
                     if data_file_url and data_file_name:
                         data_file_name = _ensure_extension(data_file_name, data_file_url, None)
+                        if not os.path.splitext(data_file_name)[1]:
+                            data_file_name += '.zip'
 
                 records.append(MetadataBundleRecord(
                     folder_name=folder_name,

--- a/odp/lib/record_dataset_bundler.py
+++ b/odp/lib/record_dataset_bundler.py
@@ -181,8 +181,6 @@ def generate_metadata_bundle(
                     data_file_name = resource['resourceDownload'].get('fileName', 'data_file')
                     if data_file_url and data_file_name:
                         data_file_name = _ensure_extension(data_file_name, data_file_url, None)
-                        if not os.path.splitext(data_file_name)[1]:
-                            data_file_name += '.zip'
 
                 records.append(MetadataBundleRecord(
                     folder_name=folder_name,


### PR DESCRIPTION
The metadata-bundle endpoint now uses MetadataBundleRequest so it correctly receives the referer field from the JSON body, extracts the catalog base URL from it, and stores it in the audit record on every download. The get_download_logs service function maps catalog_url from audit meta into the response model. The CSV export was also missing a /catalog/ path segment in the generated URLs, so links pointed to the wrong place that is now fixed. Depends on odp-core PR merging first.