### PR TITLE
fix: preserve catalog subpath prefix in download audit logs

### DIFF
--- a/odp/api/routers/catalog.py
+++ b/odp/api/routers/catalog.py
@@ -482,7 +482,11 @@ def metadata_bundle(
         catalog_url = None
         if resolved_referer:
             parsed = urlparse(resolved_referer)
-            catalog_url = f"{parsed.scheme}://{parsed.netloc}"
+            catalog_index = parsed.path.find('/catalog')
+            subpath = parsed.path[:catalog_index] if catalog_index != -1 else parsed.path
+            if not subpath.endswith('/'):
+                subpath += '/'
+            catalog_url = f"{parsed.scheme}://{parsed.netloc}{subpath}"
 
         return generate_metadata_bundle(
             record_ids=body.record_ids,

--- a/odp/lib/download_service.py
+++ b/odp/lib/download_service.py
@@ -182,7 +182,7 @@ def generate_downloads_csv(
     for d in downloads:
         meta = d.meta or {}
         dtype = meta.get('download_type')
-        catalog_url = meta.get('catalog_url', '')
+        catalog_url = meta.get('catalog_url', '').rstrip('/')
         view_link = ""
         if catalog_url and dtype == 'single_record' and meta.get('doi'):
             view_link = f"{catalog_url}/catalog/{meta.get('doi')}"


### PR DESCRIPTION
fix: preserve catalog subpath prefix in download audit logs